### PR TITLE
fix c++11 error message on install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,6 @@ setup(
     ext_modules = [Extension("_re2",
       sources = ["_re2.cc"],
       libraries = ["re2"],
+      extra_compile_args=['-std=c++11'],
       )],
     )


### PR DESCRIPTION
python setup.py will not install and results in the err message 

/usr/include/c++/4.9/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.

this will fix the error