### PR TITLE
Add RE2::Set support

### DIFF
--- a/_re2.cc
+++ b/_re2.cc
@@ -865,7 +865,7 @@ regexp_set_add(RegexpSetObject2* self, PyObject* pattern)
 
     return NULL;
   } else {
-    return PyLong_FromLong((long) seq);
+    return PyInt_FromLong(seq);
   }
 }
 
@@ -918,7 +918,7 @@ regexp_set_match(RegexpSetObject2* self, PyObject* text)
     PyObject* match_indexes = PyList_New(idxes.size());
 
     for(std::vector<int>::size_type i = 0; i != idxes.size(); i++) {
-      PyList_SetItem(match_indexes, (Py_ssize_t) i, PyLong_FromLong((long) idxes.at(i)));
+      PyList_SetItem(match_indexes, (Py_ssize_t) i, PyInt_FromLong(idxes.at(i)));
     }
 
     return match_indexes;

--- a/re2.py
+++ b/re2.py
@@ -33,13 +33,22 @@ __all__ = [
     "search",
     "match",
     "fullmatch",
-    ]
+    "Set",
+    "UNANCHORED",
+    "ANCHOR_START",
+    "ANCHOR_BOTH",
+]
 
 # Module-private compilation function, for future caching, other enhancements
 _compile = _re2._compile
 
 error = _re2.error
 escape = _re2.escape
+Set = _re2.Set
+UNANCHORED = _re2.UNANCHORED
+ANCHOR_START = _re2.ANCHOR_START
+ANCHOR_BOTH = _re2.ANCHOR_BOTH
+
 
 def compile(pattern):
     "Compile a regular expression pattern, returning a pattern object."

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -34,3 +34,88 @@ class TestMatch(unittest.TestCase):
         '''test that using the API incorrectly fails'''
         r = re2.compile('ab([cde]fg)')
         self.assertRaises(TypeError, lambda: re2.match(r, 'abdfghij'))
+
+    def test_set_unanchored(self):
+        s = re2.Set(re2.UNANCHORED)
+        s_with_default_anchoring = re2.Set()
+
+        for re2_set in [s, s_with_default_anchoring]:
+            re2_set.add('foo')
+            re2_set.add('bar')
+            re2_set.add('baz')
+            re2_set.compile()
+
+            self.assertEqual(re2_set.match('foo'), [0])
+            self.assertEqual(re2_set.match('bar'), [1])
+            self.assertEqual(re2_set.match('baz'), [2])
+            self.assertEqual(re2_set.match('afoobaryo'), [0, 1])
+
+            self.assertEqual(re2_set.match('ooba'), [])
+
+    def test_set_anchor_both(self):
+        s = re2.Set(re2.ANCHOR_BOTH)
+        s.add('foo')
+        s.add('bar')
+        s.compile()
+
+        self.assertEqual(s.match('foobar'), [])
+        self.assertEqual(s.match('fooba'), [])
+        self.assertEqual(s.match('oobar'), [])
+        self.assertEqual(s.match('foo'), [0])
+        self.assertEqual(s.match('bar'), [1])
+
+    def test_set_anchor_start(self):
+        s = re2.Set(re2.ANCHOR_START)
+        s.add('foo')
+        s.add('bar')
+        s.compile()
+
+        self.assertEqual(s.match('foobar'), [0])
+        self.assertEqual(s.match('oobar'), [])
+        self.assertEqual(s.match('foo'), [0])
+        self.assertEqual(s.match('ofoobaro'), [])
+        self.assertEqual(s.match('baro'), [1])
+
+    def test_bad_anchoring(self):
+        with self.assertRaisesRegexp(ValueError, 'anchoring must be one of.*'):
+            re2.Set(15)
+
+        with self.assertRaisesRegexp(ValueError, 'anchoring must be one of.*'):
+            re2.Set({})
+
+    def test_match_without_compile(self):
+        s = re2.Set()
+        s.add('foo')
+
+        with self.assertRaisesRegexp(RuntimeError, 'Can\'t match\(\) on an.*'):
+            s.match('bar')
+
+    def test_add_after_compile(self):
+        s = re2.Set()
+        s.add('foo')
+        s.compile()
+
+        with self.assertRaisesRegexp(RuntimeError,
+            'Can\'t add\(\) on an already compiled Set'):
+            s.add('bar')
+
+    def test_compile_on_empty(self):
+        s = re2.Set()
+        self.assertTrue(s.compile())
+
+        self.assertEqual(s.match('nah'), [])
+
+    def test_double_compile(self):
+        s = re2.Set()
+        s.add('foo')
+        self.assertTrue(s.compile())
+        self.assertTrue(s.compile())
+
+    def test_add_with_bad_pattern(self):
+        s = re2.Set()
+
+        with self.assertRaisesRegexp(ValueError, 'missing \)'):
+            s.add('(')
+
+        with self.assertRaises(TypeError):
+            s.add(3)


### PR DESCRIPTION
Adds support for RE2::Set, which is a set of patterns that can all be matched against at once, returning the indexes of the added patterns that match.

* Add re2.Set class.
* Add re2.UNANCHORED, re2.ANCHOR_START, and re2.ANCHOR_BOTH constants for specifying how a pattern should be anchored. This is currently only used by re2.Set.
* Add tests for re2.Set.

C++ is not my daily-driver language so have at it in terms of suggestions/fixes.