### PR TITLE
Add Code of Conduct and Contributer Guide

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+
+# Contributing to pyre2
+We want to make contributing to this project as easy and transparent as
+possible.
+
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
+## Pull Requests
+We actively welcome your pull requests.
+
+1. Fork the repo and create your branch from `master`.
+2. If you've added code that should be tested, add tests.
+3. If you've changed APIs, update the documentation.
+4. Ensure the test suite passes.
+5. Make sure your code lints.
+6. If you haven't already, complete the Contributor License Agreement ("CLA").
+
+## Contributor License Agreement ("CLA")
+In order to accept your pull request, we need you to submit a CLA. You only need
+to do this once to work on any of Facebook's open source projects.
+
+Complete your CLA here: <https://code.facebook.com/cla>
+
+## Issues
+We use GitHub issues to track public bugs. Please ensure your description is
+clear and has sufficient instructions to be able to reproduce the issue.
+
+Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
+disclosure of security bugs. In those cases, please go through the process
+outlined on that page and do not file a public issue.
+
+## License
+By contributing to pyre2, you agree that your contributions will be licensed
+under the LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
In the past Facebook didn't promote including these docs when creating new projects. Let's fix it. :)

Even for a stable project that is not making changes often, it can be helpful to have tips and info for potential new contributors.

why make this change?:
A Contributer Guide and Code of Conduct can both help new contributors participate in a healthy Open Source Community.

As you can see, adding these files will improve the [pyre2 community profile
checklist](https://github.com/facebook/pyre2/community) and increase the visibility of our COC.

test plan:
Viewing it on my branch -
![screen shot 2017-12-20 at 9 22 40 am](https://user-images.githubusercontent.com/1114467/34220004-db7c8d66-e567-11e7-84c6-94e6de6a5222.png)
![screen shot 2017-12-20 at 9 22 49 am](https://user-images.githubusercontent.com/1114467/34220005-db93d8cc-e567-11e7-99c4-8f79215fc0e3.png)

issue:
internal task t23481323