### PR TITLE
Port to python3

### DIFF
--- a/_re2.cc
+++ b/_re2.cc
@@ -58,8 +58,8 @@ typedef struct _MatchObject2 {
   PyObject* string;
   // There are several possible approaches to storing the matched groups:
   // 1. Fully materialize the groups tuple at match time.
-  // 2. Cache allocate PyString objects when groups are requested.
-  // 3. Always allocate new PyStrings on demand.
+  // 2. Cache allocate PyBytes objects when groups are requested.
+  // 3. Always allocate new PyBytess on demand.
   // I've chosen to go with #3.  It's the simplest, and I'm pretty sure it's
   // optimal in all cases where no group is fetched more than once.
   StringPiece* groups;
@@ -180,130 +180,143 @@ _no_setattr(PyObject* obj, PyObject* name, PyObject* v) {
   return -1;
 }
 
+#if PY_MAJOR_VERSION >= 3
+#define UNSET NULL
+#define REGEX_OBJECT_TYPE &PyUnicode_Type
+#else
+#define UNSET 0
+#define REGEX_OBJECT_TYPE &PyString_Type
+#endif
 
 static PyTypeObject Regexp_Type2 = {
   PyObject_HEAD_INIT(NULL)
-  0,                           /*ob_size*/
+#if PY_MAJOR_VERSION < 3
+  UNSET,                       /*ob_size*/
+#endif
   "_re2.RE2_Regexp",           /*tp_name*/
   sizeof(RegexpObject2),       /*tp_basicsize*/
-  0,                           /*tp_itemsize*/
+  UNSET,                           /*tp_itemsize*/
   (destructor)regexp_dealloc,  /*tp_dealloc*/
-  0,                           /*tp_print*/
-  0,                           /*tp_getattr*/
-  0,                           /*tp_setattr*/
-  0,                           /*tp_compare*/
-  0,                           /*tp_repr*/
-  0,                           /*tp_as_number*/
-  0,                           /*tp_as_sequence*/
-  0,                           /*tp_as_mapping*/
-  0,                           /*tp_hash*/
-  0,                           /*tp_call*/
-  0,                           /*tp_str*/
-  0,                           /*tp_getattro*/
+  UNSET,                           /*tp_print*/
+  UNSET,                           /*tp_getattr*/
+  UNSET,                           /*tp_setattr*/
+  UNSET,                           /*tp_compare*/
+  UNSET,                           /*tp_repr*/
+  UNSET,                           /*tp_as_number*/
+  UNSET,                           /*tp_as_sequence*/
+  UNSET,                           /*tp_as_mapping*/
+  UNSET,                           /*tp_hash*/
+  UNSET,                           /*tp_call*/
+  UNSET,                           /*tp_str*/
+  UNSET,                           /*tp_getattro*/
   _no_setattr,                 /*tp_setattro*/
-  0,                           /*tp_as_buffer*/
+  UNSET,                           /*tp_as_buffer*/
   Py_TPFLAGS_DEFAULT,          /*tp_flags*/
   "RE2 regexp objects",        /*tp_doc*/
-  0,                           /*tp_traverse*/
-  0,                           /*tp_clear*/
-  0,                           /*tp_richcompare*/
-  0,                           /*tp_weaklistoffset*/
-  0,                           /*tp_iter*/
-  0,                           /*tp_iternext*/
+  UNSET,                           /*tp_traverse*/
+  UNSET,                           /*tp_clear*/
+  UNSET,                           /*tp_richcompare*/
+  UNSET,                           /*tp_weaklistoffset*/
+  UNSET,                           /*tp_iter*/
+  UNSET,                           /*tp_iternext*/
   regexp_methods,              /*tp_methods*/
-  0,                           /*tp_members*/
-  0,                           /*tp_getset*/
-  0,                           /*tp_base*/
-  0,                           /*tp_dict*/
-  0,                           /*tp_descr_get*/
-  0,                           /*tp_descr_set*/
+  UNSET,                           /*tp_members*/
+  UNSET,                           /*tp_getset*/
+  UNSET,                           /*tp_base*/
+  UNSET,                           /*tp_dict*/
+  UNSET,                           /*tp_descr_get*/
+  UNSET,                           /*tp_descr_set*/
   offsetof(RegexpObject2, attr_dict),  /*tp_dictoffset*/
-  0,                           /*tp_init*/
-  0,                           /*tp_alloc*/
-  0,                           /*tp_new*/
+  UNSET,                           /*tp_init*/
+  UNSET,                           /*tp_alloc*/
+  UNSET,                           /*tp_new*/
 };
 
 static PyTypeObject Match_Type2 = {
   PyObject_HEAD_INIT(NULL)
-  0,                           /*ob_size*/
+#if PY_MAJOR_VERSION < 3
+  UNSET,                       /*ob_size*/
+#endif
   "_re2.RE2_Match",            /*tp_name*/
   sizeof(MatchObject2),        /*tp_basicsize*/
-  0,                           /*tp_itemsize*/
+  UNSET,                           /*tp_itemsize*/
   (destructor)match_dealloc,   /*tp_dealloc*/
-  0,                           /*tp_print*/
-  0,                           /*tp_getattr*/
-  0,                           /*tp_setattr*/
-  0,                           /*tp_compare*/
-  0,                           /*tp_repr*/
-  0,                           /*tp_as_number*/
-  0,                           /*tp_as_sequence*/
-  0,                           /*tp_as_mapping*/
-  0,                           /*tp_hash*/
-  0,                           /*tp_call*/
-  0,                           /*tp_str*/
-  0,                           /*tp_getattro*/
+  UNSET,                           /*tp_print*/
+  UNSET,                           /*tp_getattr*/
+  UNSET,                           /*tp_setattr*/
+  UNSET,                           /*tp_compare*/
+  UNSET,                           /*tp_repr*/
+  UNSET,                           /*tp_as_number*/
+  UNSET,                           /*tp_as_sequence*/
+  UNSET,                           /*tp_as_mapping*/
+  UNSET,                           /*tp_hash*/
+  UNSET,                           /*tp_call*/
+  UNSET,                           /*tp_str*/
+  UNSET,                           /*tp_getattro*/
   _no_setattr,                 /*tp_setattro*/
-  0,                           /*tp_as_buffer*/
+  UNSET,                           /*tp_as_buffer*/
   Py_TPFLAGS_DEFAULT,          /*tp_flags*/
   "RE2 match objects",         /*tp_doc*/
-  0,                           /*tp_traverse*/
-  0,                           /*tp_clear*/
-  0,                           /*tp_richcompare*/
-  0,                           /*tp_weaklistoffset*/
-  0,                           /*tp_iter*/
-  0,                           /*tp_iternext*/
+  UNSET,                           /*tp_traverse*/
+  UNSET,                           /*tp_clear*/
+  UNSET,                           /*tp_richcompare*/
+  UNSET,                           /*tp_weaklistoffset*/
+  UNSET,                           /*tp_iter*/
+  UNSET,                           /*tp_iternext*/
   match_methods,               /*tp_methods*/
-  0,                           /*tp_members*/
-  0,                           /*tp_getset*/
-  0,                           /*tp_base*/
-  0,                           /*tp_dict*/
-  0,                           /*tp_descr_get*/
-  0,                           /*tp_descr_set*/
+  UNSET,                           /*tp_members*/
+  UNSET,                           /*tp_getset*/
+  UNSET,                           /*tp_base*/
+  UNSET,                           /*tp_dict*/
+  UNSET,                           /*tp_descr_get*/
+  UNSET,                           /*tp_descr_set*/
   offsetof(MatchObject2, attr_dict),  /*tp_dictoffset*/
-  0,                           /*tp_init*/
-  0,                           /*tp_alloc*/
-  0,                           /*tp_new*/
+  UNSET,                           /*tp_init*/
+  UNSET,                           /*tp_alloc*/
+  UNSET,                           /*tp_new*/
 };
 
 static PyTypeObject RegexpSet_Type2 = {
   PyObject_HEAD_INIT(NULL)
-  0,                               /*ob_size*/
+#if PY_MAJOR_VERSION < 3
+  UNSET,                       /*ob_size*/
+#endif
   "_re2.RE2_Set",                  /*tp_name*/
   sizeof(RegexpSetObject2),        /*tp_basicsize*/
-  0,                               /*tp_itemsize*/
+  UNSET,                               /*tp_itemsize*/
   (destructor)regexp_set_dealloc,  /*tp_dealloc*/
-  0,                               /*tp_print*/
-  0,                               /*tp_getattr*/
-  0,                               /*tp_setattr*/
-  0,                               /*tp_compare*/
-  0,                               /*tp_repr*/
-  0,                               /*tp_as_number*/
-  0,                               /*tp_as_sequence*/
-  0,                               /*tp_as_mapping*/
-  0,                               /*tp_hash*/
-  0,                               /*tp_call*/
-  0,                               /*tp_str*/
-  0,                               /*tp_getattro*/
+  UNSET,                               /*tp_print*/
+  UNSET,                               /*tp_getattr*/
+  UNSET,                               /*tp_setattr*/
+  UNSET,                               /*tp_compare*/
+  UNSET,                               /*tp_repr*/
+  UNSET,                               /*tp_as_number*/
+  UNSET,                               /*tp_as_sequence*/
+  UNSET,                               /*tp_as_mapping*/
+  UNSET,                               /*tp_hash*/
+  UNSET,                               /*tp_call*/
+  UNSET,                               /*tp_str*/
+  UNSET,                               /*tp_getattro*/
   _no_setattr,                     /*tp_setattro*/
-  0,                               /*tp_as_buffer*/
+  UNSET,                               /*tp_as_buffer*/
   Py_TPFLAGS_DEFAULT,              /*tp_flags*/
   "RE2 regexp set objects",        /*tp_doc*/
-  0,                               /*tp_traverse*/
-  0,                               /*tp_clear*/
-  0,                               /*tp_richcompare*/
-  0,                               /*tp_weaklistoffset*/
-  0,                               /*tp_iter*/
-  0,                               /*tp_iternext*/
+  UNSET,                               /*tp_traverse*/
+  UNSET,                               /*tp_clear*/
+  UNSET,                               /*tp_richcompare*/
+  UNSET,                               /*tp_weaklistoffset*/
+  UNSET,                               /*tp_iter*/
+  UNSET,                               /*tp_iternext*/
   regexp_set_methods,              /*tp_methods*/
-  0,                               /*tp_members*/
-  0,                               /*tp_getset*/
-  0,                               /*tp_base*/
-  0,                               /*tp_dict*/
-  0,                               /*tp_descr_get*/
-  0,                               /*tp_descr_set*/
-  0,                               /*tp_dictoffset*/
-  0,                               /*tp_init*/
-  0,                               /*tp_alloc*/
+  UNSET,                               /*tp_members*/
+  UNSET,                               /*tp_getset*/
+  UNSET,                               /*tp_base*/
+  UNSET,                               /*tp_dict*/
+  UNSET,                               /*tp_descr_get*/
+  UNSET,                               /*tp_descr_set*/
+  UNSET,                               /*tp_dictoffset*/
+  UNSET,                               /*tp_init*/
+  UNSET,                               /*tp_alloc*/
   regexp_set_new,                  /*tp_new*/
 };
 
@@ -326,8 +339,13 @@ create_regexp(PyObject* pattern)
   regexp->re2_obj = NULL;
   regexp->attr_dict = NULL;
 
+  Py_ssize_t len_pattern;
+#if PY_MAJOR_VERSION >= 3
+  const char* raw_pattern = PyUnicode_AsUTF8AndSize(pattern, &len_pattern);
+#else
   const char* raw_pattern = PyString_AS_STRING(pattern);
-  Py_ssize_t len_pattern = PyString_GET_SIZE(pattern);
+  len_pattern = PyString_GET_SIZE(pattern);
+#endif
 
   RE2::Options options;
   options.set_log_errors(false);
@@ -372,7 +390,7 @@ create_regexp(PyObject* pattern)
 
   const std::map<std::string, int>& name_map = regexp->re2_obj->NamedCapturingGroups();
   for (std::map<std::string, int>::const_iterator it = name_map.begin(); it != name_map.end(); ++it) {
-    PyObject* index = PyInt_FromLong(it->second);
+    PyObject* index = PyLong_FromLong(it->second);
     if (index == NULL) {
       Py_DECREF(regexp);
       return NULL;
@@ -403,14 +421,29 @@ _do_search(RegexpObject2* self, PyObject* args, PyObject* kwds, RE2::Anchor anch
 
   // Using O! instead of s# here, because we want to stash the original
   // PyObject* in the match object on a successful match.
-  if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!|ll", (char**)kwlist,
-        &PyString_Type, &string,
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|ll", (char**)kwlist,
+        &string,
         &pos, &endpos)) {
     return NULL;
   }
 
-  const char* subject = PyString_AS_STRING(string);
-  Py_ssize_t slen = PyString_GET_SIZE(string);
+  const char *subject;
+  Py_ssize_t slen;
+#if PY_MAJOR_VERSION >= 3
+  if (PyBytes_Check(string)) {
+    subject = PyBytes_AS_STRING(string);
+    slen = PyBytes_GET_SIZE(string);
+  } else if (PyUnicode_Check(string)) {
+    subject = PyUnicode_AsUTF8AndSize(string, &slen);
+  } else {
+    Py_DECREF(string);
+    PyErr_SetString(PyExc_TypeError, "can only operate on unicode or bytes");
+    return NULL;
+  } 
+#else
+  subject = PyString_AS_STRING(string);
+  slen = PyString_GET_SIZE(string);
+#endif
   if (pos < 0) pos = 0;
   if (pos > slen) pos = slen;
   if (endpos < pos) endpos = pos;
@@ -540,7 +573,7 @@ _group_idx(MatchObject2* self, PyObject* group, long* idx_p)
     return false;
   }
   PyErr_Clear(); // Is this necessary?
-  long idx = PyInt_AsLong(group);
+  long idx = PyLong_AsLong(group);
   if (idx == -1 && PyErr_Occurred() != NULL) {
     return false;
   }
@@ -567,7 +600,16 @@ _group_span(MatchObject2* self, long idx, Py_ssize_t* o_start, Py_ssize_t* o_end
     *o_end = -1;
     return false;
   }
-  Py_ssize_t start = piece.data() - PyString_AS_STRING(self->string);
+  Py_ssize_t start;
+#if PY_MAJOR_VERSION >= 3
+  if (PyBytes_Check(self->string)) {
+    start = piece.data() - PyBytes_AS_STRING(self->string);
+  } else {
+    start = piece.data() - PyUnicode_AsUTF8AndSize(self->string, NULL);
+  }
+#else
+  start = piece.data() - PyString_AS_STRING(self->string);
+#endif
   *o_start = start;
   *o_end = start + piece.length();
   return true;
@@ -813,12 +855,18 @@ regexp_set_add(RegexpSetObject2* self, PyObject* pattern)
     return NULL;
   }
 
+  Py_ssize_t len_pattern;
+#if PY_MAJOR_VERSION >= 3
+  const char* raw_pattern = PyUnicode_AsUTF8AndSize(pattern, &len_pattern);
+#else
   const char* raw_pattern = PyString_AsString(pattern);
+#endif
   if (!raw_pattern) {
     return NULL;
   }
-  Py_ssize_t len_pattern = PyString_GET_SIZE(pattern);
-
+#if PY_MAJOR_VERSION <3
+  len_pattern = PyString_GET_SIZE(pattern);
+#endif
   std::string add_error;
   int seq = self->re2_set_obj->Add(StringPiece(raw_pattern, (int)len_pattern), &add_error);
 
@@ -827,7 +875,7 @@ regexp_set_add(RegexpSetObject2* self, PyObject* pattern)
     return NULL;
   }
 
-  return PyInt_FromLong(seq);
+  return PyLong_FromLong(seq);
 }
 
 static PyObject*
@@ -856,11 +904,25 @@ regexp_set_match(RegexpSetObject2* self, PyObject* text)
     return NULL;
   }
 
-  const char* raw_text = PyString_AsString(text);
+  const char* raw_text;
+  Py_ssize_t len_text;
+#if PY_MAJOR_VERSION >= 3
+  if (PyBytes_Check(text)) {
+    raw_text = PyBytes_AsString(text);
+    len_text = PyBytes_GET_SIZE(text);
+  } else if (PyUnicode_Check(text)) {
+    raw_text = PyUnicode_AsUTF8AndSize(text, &len_text);
+  } else {
+    PyErr_SetString(PyExc_TypeError, "expected str or bytes");
+    return NULL;
+  }
+#else
+  raw_text = PyString_AsString(text);
+  len_text = PyString_GET_SIZE(text);
+#endif
   if (!raw_text) {
     return NULL;
   }
-  Py_ssize_t len_text = PyString_GET_SIZE(text);
 
   std::vector<int> idxes;
   bool matched = self->re2_set_obj->Match(StringPiece(raw_text, (int)len_text), &idxes);
@@ -869,7 +931,7 @@ regexp_set_match(RegexpSetObject2* self, PyObject* text)
     PyObject* match_indexes = PyList_New(idxes.size());
 
     for(std::vector<int>::size_type i = 0; i < idxes.size(); ++i) {
-      PyList_SET_ITEM(match_indexes, (Py_ssize_t)i, PyInt_FromLong(idxes[i]));
+      PyList_SET_ITEM(match_indexes, (Py_ssize_t)i, PyLong_FromLong(idxes[i]));
     }
 
     return match_indexes;
@@ -889,7 +951,7 @@ _compile(PyObject* self, PyObject* args, PyObject* kwds)
   PyObject *pattern;
 
   if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!:_compile", (char**)kwlist,
-                                   &PyString_Type, &pattern)) {
+                                   REGEX_OBJECT_TYPE, &pattern)) {
     return NULL;
   }
 
@@ -908,7 +970,7 @@ escape(PyObject* self, PyObject* args)
 
   std::string esc(RE2::QuoteMeta(StringPiece(str, (int)len)));
 
-  return PyString_FromStringAndSize(esc.c_str(), esc.size());
+  return PyBytes_FromStringAndSize(esc.c_str(), esc.size());
 }
 
 static PyMethodDef methods[] = {
@@ -918,31 +980,59 @@ static PyMethodDef methods[] = {
   {NULL}  /* Sentinel */
 };
 
+
+#if PY_MAJOR_VERSION >= 3
+static struct PyModuleDef moduledef = {
+  PyModuleDef_HEAD_INIT,
+  "_re2",
+  NULL,
+  0,
+  methods,
+  NULL,
+  NULL, // myextension_traverse,
+  NULL, // myextension_clear,
+  NULL
+};
+
+#define INITERROR return NULL
+#else
+#define INITERROR return
+#endif
+
+
 PyMODINIT_FUNC
+#if PY_MAJOR_VERSION >= 3
+PyInit__re2(void)
+#else
 init_re2(void)
+#endif
 {
   if (PyType_Ready(&Regexp_Type2) < 0) {
-    return;
+    INITERROR;
   }
 
   if (PyType_Ready(&Match_Type2) < 0) {
-    return;
+    INITERROR;
   }
 
   if (PyType_Ready(&RegexpSet_Type2) < 0) {
-    return;
+    INITERROR;
   }
 
   PyObject* sre_mod = PyImport_ImportModuleNoBlock("sre_constants");
   if (sre_mod == NULL) {
-    return;
+    INITERROR;
   }
   /* static global */ error_class = PyObject_GetAttrString(sre_mod, "error");
   if (error_class == NULL) {
-    return;
+    INITERROR;
   }
 
+#if PY_MAJOR_VERSION >= 3
+  PyObject* mod = PyModule_Create(&moduledef);
+#else
   PyObject* mod = Py_InitModule("_re2", methods);
+#endif
 
   Py_INCREF(error_class);
   PyModule_AddObject(mod, "error", error_class);
@@ -953,4 +1043,7 @@ init_re2(void)
   PyModule_AddIntConstant(mod, "UNANCHORED", RE2::UNANCHORED);
   PyModule_AddIntConstant(mod, "ANCHOR_START", RE2::ANCHOR_START);
   PyModule_AddIntConstant(mod, "ANCHOR_BOTH", RE2::ANCHOR_BOTH);
+#if PY_MAJOR_VERSION >= 3
+  return mod;
+#endif
 }

--- a/_re2.cc
+++ b/_re2.cc
@@ -58,7 +58,7 @@ typedef struct _MatchObject2 {
   PyObject* string;
   // There are several possible approaches to storing the matched groups:
   // 1. Fully materialize the groups tuple at match time.
-  // 2. Cache allocate PyBytes objects when groups are requested.
+  // 2. Cache allocated PyBytes objects when groups are requested.
   // 3. Always allocate new PyBytess on demand.
   // I've chosen to go with #3.  It's the simplest, and I'm pretty sure it's
   // optimal in all cases where no group is fetched more than once.
@@ -185,7 +185,7 @@ _no_setattr(PyObject* obj, PyObject* name, PyObject* v) {
 static PyTypeObject Regexp_Type2 = {
   PyObject_HEAD_INIT(NULL)
 #if PY_MAJOR_VERSION < 3
-  0,                       /*ob_size*/
+  0,                           /*ob_size*/
 #endif
   "_re2.RE2_Regexp",           /*tp_name*/
   sizeof(RegexpObject2),       /*tp_basicsize*/
@@ -384,6 +384,8 @@ create_regexp(PyObject* self, PyObject* pattern, PyObject* error_class)
 
   const std::map<std::string, int>& name_map = regexp->re2_obj->NamedCapturingGroups();
   for (std::map<std::string, int>::const_iterator it = name_map.begin(); it != name_map.end(); ++it) {
+    // This used to return an int() on Py2, but now returns a long() to be
+    // consistent across Py3 and Py2.
     PyObject* index = PyLong_FromLong(it->second);
     if (index == NULL) {
       Py_DECREF(regexp);
@@ -413,7 +415,7 @@ _do_search(RegexpObject2* self, PyObject* args, PyObject* kwds, RE2::Anchor anch
     "endpos",
     NULL};
 
-  // Using O! instead of s# here, because we want to stash the original
+  // Using O instead of s# here, because we want to stash the original
   // PyObject* in the match object on a successful match.
   if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|ll", (char**)kwlist,
         &string,
@@ -430,14 +432,12 @@ _do_search(RegexpObject2* self, PyObject* args, PyObject* kwds, RE2::Anchor anch
     subject = PyBytes_AS_STRING(string);
     slen = PyBytes_GET_SIZE(string);
   } else {
-    Py_DECREF(string);
     PyErr_SetString(PyExc_TypeError, "can only operate on unicode or bytes");
     return NULL;
   } 
 #else
   subject = PyString_AsString(string);
   if (subject == NULL) {
-    Py_DECREF(string);
     return NULL;
   }
   slen = PyString_GET_SIZE(string);

--- a/_re2.cc
+++ b/_re2.cc
@@ -177,142 +177,140 @@ _no_setattr(PyObject* obj, PyObject* name, PyObject* v) {
 }
 
 #if PY_MAJOR_VERSION >= 3
-#define UNSET NULL
 #define REGEX_OBJECT_TYPE &PyUnicode_Type
 #else
-#define UNSET 0
 #define REGEX_OBJECT_TYPE &PyString_Type
 #endif
 
 static PyTypeObject Regexp_Type2 = {
   PyObject_HEAD_INIT(NULL)
 #if PY_MAJOR_VERSION < 3
-  UNSET,                       /*ob_size*/
+  0,                       /*ob_size*/
 #endif
   "_re2.RE2_Regexp",           /*tp_name*/
   sizeof(RegexpObject2),       /*tp_basicsize*/
-  UNSET,                           /*tp_itemsize*/
+  0,                           /*tp_itemsize*/
   (destructor)regexp_dealloc,  /*tp_dealloc*/
-  UNSET,                           /*tp_print*/
-  UNSET,                           /*tp_getattr*/
-  UNSET,                           /*tp_setattr*/
-  UNSET,                           /*tp_compare*/
-  UNSET,                           /*tp_repr*/
-  UNSET,                           /*tp_as_number*/
-  UNSET,                           /*tp_as_sequence*/
-  UNSET,                           /*tp_as_mapping*/
-  UNSET,                           /*tp_hash*/
-  UNSET,                           /*tp_call*/
-  UNSET,                           /*tp_str*/
-  UNSET,                           /*tp_getattro*/
+  0,                           /*tp_print*/
+  0,                           /*tp_getattr*/
+  0,                           /*tp_setattr*/
+  0,                           /*tp_compare*/
+  0,                           /*tp_repr*/
+  0,                           /*tp_as_number*/
+  0,                           /*tp_as_sequence*/
+  0,                           /*tp_as_mapping*/
+  0,                           /*tp_hash*/
+  0,                           /*tp_call*/
+  0,                           /*tp_str*/
+  0,                           /*tp_getattro*/
   _no_setattr,                 /*tp_setattro*/
-  UNSET,                           /*tp_as_buffer*/
+  0,                           /*tp_as_buffer*/
   Py_TPFLAGS_DEFAULT,          /*tp_flags*/
   "RE2 regexp objects",        /*tp_doc*/
-  UNSET,                           /*tp_traverse*/
-  UNSET,                           /*tp_clear*/
-  UNSET,                           /*tp_richcompare*/
-  UNSET,                           /*tp_weaklistoffset*/
-  UNSET,                           /*tp_iter*/
-  UNSET,                           /*tp_iternext*/
+  0,                           /*tp_traverse*/
+  0,                           /*tp_clear*/
+  0,                           /*tp_richcompare*/
+  0,                           /*tp_weaklistoffset*/
+  0,                           /*tp_iter*/
+  0,                           /*tp_iternext*/
   regexp_methods,              /*tp_methods*/
-  UNSET,                           /*tp_members*/
-  UNSET,                           /*tp_getset*/
-  UNSET,                           /*tp_base*/
-  UNSET,                           /*tp_dict*/
-  UNSET,                           /*tp_descr_get*/
-  UNSET,                           /*tp_descr_set*/
+  0,                           /*tp_members*/
+  0,                           /*tp_getset*/
+  0,                           /*tp_base*/
+  0,                           /*tp_dict*/
+  0,                           /*tp_descr_get*/
+  0,                           /*tp_descr_set*/
   offsetof(RegexpObject2, attr_dict),  /*tp_dictoffset*/
-  UNSET,                           /*tp_init*/
-  UNSET,                           /*tp_alloc*/
-  UNSET,                           /*tp_new*/
+  0,                           /*tp_init*/
+  0,                           /*tp_alloc*/
+  0,                           /*tp_new*/
 };
 
 static PyTypeObject Match_Type2 = {
   PyObject_HEAD_INIT(NULL)
 #if PY_MAJOR_VERSION < 3
-  UNSET,                       /*ob_size*/
+  0,                       /*ob_size*/
 #endif
   "_re2.RE2_Match",            /*tp_name*/
   sizeof(MatchObject2),        /*tp_basicsize*/
-  UNSET,                           /*tp_itemsize*/
+  0,                           /*tp_itemsize*/
   (destructor)match_dealloc,   /*tp_dealloc*/
-  UNSET,                           /*tp_print*/
-  UNSET,                           /*tp_getattr*/
-  UNSET,                           /*tp_setattr*/
-  UNSET,                           /*tp_compare*/
-  UNSET,                           /*tp_repr*/
-  UNSET,                           /*tp_as_number*/
-  UNSET,                           /*tp_as_sequence*/
-  UNSET,                           /*tp_as_mapping*/
-  UNSET,                           /*tp_hash*/
-  UNSET,                           /*tp_call*/
-  UNSET,                           /*tp_str*/
-  UNSET,                           /*tp_getattro*/
+  0,                           /*tp_print*/
+  0,                           /*tp_getattr*/
+  0,                           /*tp_setattr*/
+  0,                           /*tp_compare*/
+  0,                           /*tp_repr*/
+  0,                           /*tp_as_number*/
+  0,                           /*tp_as_sequence*/
+  0,                           /*tp_as_mapping*/
+  0,                           /*tp_hash*/
+  0,                           /*tp_call*/
+  0,                           /*tp_str*/
+  0,                           /*tp_getattro*/
   _no_setattr,                 /*tp_setattro*/
-  UNSET,                           /*tp_as_buffer*/
+  0,                           /*tp_as_buffer*/
   Py_TPFLAGS_DEFAULT,          /*tp_flags*/
   "RE2 match objects",         /*tp_doc*/
-  UNSET,                           /*tp_traverse*/
-  UNSET,                           /*tp_clear*/
-  UNSET,                           /*tp_richcompare*/
-  UNSET,                           /*tp_weaklistoffset*/
-  UNSET,                           /*tp_iter*/
-  UNSET,                           /*tp_iternext*/
+  0,                           /*tp_traverse*/
+  0,                           /*tp_clear*/
+  0,                           /*tp_richcompare*/
+  0,                           /*tp_weaklistoffset*/
+  0,                           /*tp_iter*/
+  0,                           /*tp_iternext*/
   match_methods,               /*tp_methods*/
-  UNSET,                           /*tp_members*/
-  UNSET,                           /*tp_getset*/
-  UNSET,                           /*tp_base*/
-  UNSET,                           /*tp_dict*/
-  UNSET,                           /*tp_descr_get*/
-  UNSET,                           /*tp_descr_set*/
+  0,                           /*tp_members*/
+  0,                           /*tp_getset*/
+  0,                           /*tp_base*/
+  0,                           /*tp_dict*/
+  0,                           /*tp_descr_get*/
+  0,                           /*tp_descr_set*/
   offsetof(MatchObject2, attr_dict),  /*tp_dictoffset*/
-  UNSET,                           /*tp_init*/
-  UNSET,                           /*tp_alloc*/
-  UNSET,                           /*tp_new*/
+  0,                           /*tp_init*/
+  0,                           /*tp_alloc*/
+  0,                           /*tp_new*/
 };
 
 static PyTypeObject RegexpSet_Type2 = {
   PyObject_HEAD_INIT(NULL)
 #if PY_MAJOR_VERSION < 3
-  UNSET,                       /*ob_size*/
+  0,                       /*ob_size*/
 #endif
   "_re2.RE2_Set",                  /*tp_name*/
   sizeof(RegexpSetObject2),        /*tp_basicsize*/
-  UNSET,                               /*tp_itemsize*/
+  0,                               /*tp_itemsize*/
   (destructor)regexp_set_dealloc,  /*tp_dealloc*/
-  UNSET,                               /*tp_print*/
-  UNSET,                               /*tp_getattr*/
-  UNSET,                               /*tp_setattr*/
-  UNSET,                               /*tp_compare*/
-  UNSET,                               /*tp_repr*/
-  UNSET,                               /*tp_as_number*/
-  UNSET,                               /*tp_as_sequence*/
-  UNSET,                               /*tp_as_mapping*/
-  UNSET,                               /*tp_hash*/
-  UNSET,                               /*tp_call*/
-  UNSET,                               /*tp_str*/
-  UNSET,                               /*tp_getattro*/
+  0,                               /*tp_print*/
+  0,                               /*tp_getattr*/
+  0,                               /*tp_setattr*/
+  0,                               /*tp_compare*/
+  0,                               /*tp_repr*/
+  0,                               /*tp_as_number*/
+  0,                               /*tp_as_sequence*/
+  0,                               /*tp_as_mapping*/
+  0,                               /*tp_hash*/
+  0,                               /*tp_call*/
+  0,                               /*tp_str*/
+  0,                               /*tp_getattro*/
   _no_setattr,                     /*tp_setattro*/
-  UNSET,                               /*tp_as_buffer*/
+  0,                               /*tp_as_buffer*/
   Py_TPFLAGS_DEFAULT,              /*tp_flags*/
   "RE2 regexp set objects",        /*tp_doc*/
-  UNSET,                               /*tp_traverse*/
-  UNSET,                               /*tp_clear*/
-  UNSET,                               /*tp_richcompare*/
-  UNSET,                               /*tp_weaklistoffset*/
-  UNSET,                               /*tp_iter*/
-  UNSET,                               /*tp_iternext*/
+  0,                               /*tp_traverse*/
+  0,                               /*tp_clear*/
+  0,                               /*tp_richcompare*/
+  0,                               /*tp_weaklistoffset*/
+  0,                               /*tp_iter*/
+  0,                               /*tp_iternext*/
   regexp_set_methods,              /*tp_methods*/
-  UNSET,                               /*tp_members*/
-  UNSET,                               /*tp_getset*/
-  UNSET,                               /*tp_base*/
-  UNSET,                               /*tp_dict*/
-  UNSET,                               /*tp_descr_get*/
-  UNSET,                               /*tp_descr_set*/
-  UNSET,                               /*tp_dictoffset*/
-  UNSET,                               /*tp_init*/
-  UNSET,                               /*tp_alloc*/
+  0,                               /*tp_members*/
+  0,                               /*tp_getset*/
+  0,                               /*tp_base*/
+  0,                               /*tp_dict*/
+  0,                               /*tp_descr_get*/
+  0,                               /*tp_descr_set*/
+  0,                               /*tp_dictoffset*/
+  0,                               /*tp_init*/
+  0,                               /*tp_alloc*/
   regexp_set_new,                  /*tp_new*/
 };
 
@@ -426,18 +424,22 @@ _do_search(RegexpObject2* self, PyObject* args, PyObject* kwds, RE2::Anchor anch
   const char *subject;
   Py_ssize_t slen;
 #if PY_MAJOR_VERSION >= 3
-  if (PyBytes_Check(string)) {
+  if (PyUnicode_Check(string)) {
+    subject = PyUnicode_AsUTF8AndSize(string, &slen);
+  } else if (PyBytes_Check(string)) {
     subject = PyBytes_AS_STRING(string);
     slen = PyBytes_GET_SIZE(string);
-  } else if (PyUnicode_Check(string)) {
-    subject = PyUnicode_AsUTF8AndSize(string, &slen);
   } else {
     Py_DECREF(string);
     PyErr_SetString(PyExc_TypeError, "can only operate on unicode or bytes");
     return NULL;
   } 
 #else
-  subject = PyString_AS_STRING(string);
+  subject = PyString_AsString(string);
+  if (subject == NULL) {
+    Py_DECREF(string);
+    return NULL;
+  }
   slen = PyString_GET_SIZE(string);
 #endif
   if (pos < 0) pos = 0;
@@ -854,13 +856,14 @@ regexp_set_add(RegexpSetObject2* self, PyObject* pattern)
   Py_ssize_t len_pattern;
 #if PY_MAJOR_VERSION >= 3
   const char* raw_pattern = PyUnicode_AsUTF8AndSize(pattern, &len_pattern);
-#else
-  const char* raw_pattern = PyString_AsString(pattern);
-#endif
   if (!raw_pattern) {
     return NULL;
   }
-#if PY_MAJOR_VERSION <3
+#else
+  const char* raw_pattern = PyString_AsString(pattern);
+  if (!raw_pattern) {
+    return NULL;
+  }
   len_pattern = PyString_GET_SIZE(pattern);
 #endif
   std::string add_error;
@@ -903,22 +906,22 @@ regexp_set_match(RegexpSetObject2* self, PyObject* text)
   const char* raw_text;
   Py_ssize_t len_text;
 #if PY_MAJOR_VERSION >= 3
-  if (PyBytes_Check(text)) {
-    raw_text = PyBytes_AsString(text);
-    len_text = PyBytes_GET_SIZE(text);
-  } else if (PyUnicode_Check(text)) {
+  if (PyUnicode_Check(text)) {
     raw_text = PyUnicode_AsUTF8AndSize(text, &len_text);
+  } else if (PyBytes_Check(text)) {
+    raw_text = PyBytes_AS_STRING(text);
+    len_text = PyBytes_GET_SIZE(text);
   } else {
     PyErr_SetString(PyExc_TypeError, "expected str or bytes");
     return NULL;
   }
 #else
   raw_text = PyString_AsString(text);
-  len_text = PyString_GET_SIZE(text);
-#endif
-  if (!raw_text) {
+  if (raw_text == NULL) {
     return NULL;
   }
+  len_text = PyString_GET_SIZE(text);
+#endif
 
   std::vector<int> idxes;
   bool matched = self->re2_set_obj->Match(StringPiece(raw_text, (int)len_text), &idxes);

--- a/re2.py
+++ b/re2.py
@@ -25,6 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import _re2
+import sre_constants
 
 __all__ = [
     "error",
@@ -42,7 +43,7 @@ __all__ = [
 # Module-private compilation function, for future caching, other enhancements
 _compile = _re2._compile
 
-error = _re2.error
+error = sre_constants.error
 escape = _re2.escape
 Set = _re2.Set
 UNANCHORED = _re2.UNANCHORED
@@ -52,19 +53,19 @@ ANCHOR_BOTH = _re2.ANCHOR_BOTH
 
 def compile(pattern):
     "Compile a regular expression pattern, returning a pattern object."
-    return _compile(pattern)
+    return _compile(pattern, error)
 
 def search(pattern, string):
     """Scan through string looking for a match to the pattern, returning
     a match object, or None if no match was found."""
-    return _compile(pattern).search(string)
+    return _compile(pattern, error).search(string)
 
 def match(pattern, string):
     """Try to apply the pattern at the start of the string, returning
     a match object, or None if no match was found."""
-    return _compile(pattern).match(string)
+    return _compile(pattern, error).match(string)
 
 def fullmatch(pattern, string):
     """Try to apply the pattern to the entire string, returning
     a match object, or None if no match was found."""
-    return _compile(pattern).fullmatch(string)
+    return _compile(pattern, error).fullmatch(string)

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -35,6 +35,39 @@ class TestMatch(unittest.TestCase):
         r = re2.compile('ab([cde]fg)')
         self.assertRaises(TypeError, lambda: re2.match(r, 'abdfghij'))
 
+    def test_match_bytes(self):
+        ''' test that we can match things in the bytes type '''
+        r = re2.compile('(\\x09)')
+        m = r.match(b'\x09')
+        self.assertIsNotNone(m)
+        g = m.groups()
+        self.assertTrue(isinstance(g, tuple))
+        self.assertTrue(isinstance(g[0], bytes))
+        self.assertEqual(b'\x09', g[0])
+
+    def test_match_str(self):
+        ''' test that we can match binary things in the str type '''
+        r = re2.compile('(\\x09)')
+        m = r.match('\x09')
+        self.assertIsNotNone(m)
+        g = m.groups()
+        self.assertTrue(isinstance(g, tuple))
+        self.assertTrue(isinstance(g[0], str))
+        self.assertEqual('\x09', g[0])
+
+    def test_match_bad_utf8_bytes(self):
+        ''' Validate that we just return None on invalid utf-8 '''
+        r = re2.compile('\\x80')
+        m = r.match(b'\x80')
+        self.assertIsNone(m)
+
+    def test_span_type(self):
+        ''' verify that start/end return the native literal integer type '''
+        r = re2.compile('abc')
+        m = r.match('abc')
+        self.assertTrue(isinstance(m.start(), type(1)))
+        self.assertTrue(isinstance(m.end(), type(1)))
+
     def test_set_unanchored(self):
         s = re2.Set(re2.UNANCHORED)
         s_with_default_anchoring = re2.Set()


### PR DESCRIPTION
Testing was done against Python 2.7 and 3.5 on Ubuntu 16.04. All tests
pass cleanly in both. More tests may be needed to ensure bytes and
strings work as expected on py3.