### PR TITLE
Performance improvements for pyre2

### DIFF
--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -10,6 +10,13 @@ class TestMatch(unittest.TestCase):
         self.assertEqual(m.span(), (0, 3))
         self.assertEqual(m.groups(), tuple())
         self.assertEqual(m.groupdict(), {})
+        self.assertEqual(m.pos, 0)
+        self.assertEqual(m.endpos, 3)
+        self.assertEqual(m.string, 'abc')
+        self.assertIsNotNone(m.re)
+        self.assertEqual(m.re.pattern, 'abc')
+        self.assertEqual(m.re.groups, 0)
+        self.assertEqual(m.re.groupindex, {})
 
     def test_group_match(self):
         m = re2.match('ab([cde]fg)', 'abdfghij')
@@ -19,6 +26,29 @@ class TestMatch(unittest.TestCase):
         self.assertEqual(m.span(), (0, 5))
         self.assertEqual(m.groups(), ('dfg',))
         self.assertEqual(m.groupdict(), {})
+        self.assertEqual(m.pos, 0)
+        self.assertEqual(m.endpos, 8)
+        self.assertEqual(m.string, 'abdfghij')
+        self.assertIsNotNone(m.re)
+        self.assertEqual(m.re.pattern, 'ab([cde]fg)')
+        self.assertEqual(m.re.groups, 1)
+        self.assertEqual(m.re.groupindex, {})
+
+    def test_named_group_match(self):
+        m = re2.match('ab(?P<testgroup>[cde]fg)', 'abdfghij')
+        self.assertIsNotNone(m)
+        self.assertEqual(m.start(), 0)
+        self.assertEqual(m.end(), 5)
+        self.assertEqual(m.span(), (0, 5))
+        self.assertEqual(m.groups(), ('dfg',))
+        self.assertEqual(m.groupdict(), {'testgroup': 'dfg'})
+        self.assertEqual(m.pos, 0)
+        self.assertEqual(m.endpos, 8)
+        self.assertEqual(m.string, 'abdfghij')
+        self.assertIsNotNone(m.re)
+        self.assertEqual(m.re.pattern, 'ab(?P<testgroup>[cde]fg)')
+        self.assertEqual(m.re.groups, 1)
+        self.assertEqual(m.re.groupindex, {'testgroup': 1})
 
     def test_compiled_match(self):
         r = re2.compile('ab([cde]fg)')
@@ -29,6 +59,13 @@ class TestMatch(unittest.TestCase):
         self.assertEqual(m.span(), (0, 5))
         self.assertEqual(m.groups(), ('dfg',))
         self.assertEqual(m.groupdict(), {})
+        self.assertEqual(m.pos, 0)
+        self.assertEqual(m.endpos, 8)
+        self.assertEqual(m.string, 'abdfghij')
+        self.assertIsNotNone(m.re)
+        self.assertEqual(m.re.pattern, 'ab([cde]fg)')
+        self.assertEqual(m.re.groups, 1)
+        self.assertEqual(m.re.groupindex, {})
 
     def test_match_raise(self):
         '''test that using the API incorrectly fails'''
@@ -44,6 +81,13 @@ class TestMatch(unittest.TestCase):
         self.assertTrue(isinstance(g, tuple))
         self.assertTrue(isinstance(g[0], bytes))
         self.assertEqual(b'\x09', g[0])
+        self.assertEqual(m.pos, 0)
+        self.assertEqual(m.endpos, 1)
+        self.assertEqual(m.string, b'\x09')
+        self.assertIsNotNone(m.re)
+        self.assertEqual(m.re.pattern, '(\\x09)')
+        self.assertEqual(m.re.groups, 1)
+        self.assertEqual(m.re.groupindex, {})
 
     def test_match_str(self):
         ''' test that we can match binary things in the str type '''
@@ -60,6 +104,10 @@ class TestMatch(unittest.TestCase):
         r = re2.compile('\\x80')
         m = r.match(b'\x80')
         self.assertIsNone(m)
+
+    def test_invalid_pattern(self):
+        ''' Verify that bad patterns raise an exception '''
+        self.assertRaises(Exception, lambda: re2.compile(')'))
 
     def test_span_type(self):
         ''' verify that start/end return the native literal integer type '''


### PR DESCRIPTION
As part of a quick test I did to measure the performance of pyre2, I noticed
hat we spent a lot of time allocating objects and that we could improve
the performance simply by altering some of the C code to limit unnecessary
object allocations. The main culprit was `Py_BuildValue` but it seems like the
changes had a positive effect overall in terms of performance.

As part of that I did:

* Deleted code that populated attributes of the attr_dict struct
* Deleted code that initialized the struct itself

This is more of a request for comments about these changes, just to get some initial feedback based on the changes because I might be missing something obvious but as far as I can see nothing has broken and we have performance improvements ranging from 5% to 50% depending on the use case.

* Before change:
```python
In [1]: import re2

In [2]: import timeit

In [3]: r = re2.compile('\w+')

In [4]: %timeit r.match('foo bar')
1000000 loops, best of 3: 408 ns per loop

In [5]: r = re2.compile('(?P<test>\w*)')

In [6]: %timeit r.match('foo bar')
1000000 loops, best of 3: 419 ns per loop

In [7]: email_regex = '(?:[a-z0-9!#$%&\'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&\'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])'

In [8]: r = re2.compile(email_regex)

In [9]: %timeit r.match('foo@bar.com')
1000000 loops, best of 3: 1.04 µs per loop
```
* After change:
```python
In [1]: import re2

In [2]: import timeit

In [3]: r = re2.compile('\w+')

In [4]: %timeit r.match('foo bar')
1000000 loops, best of 3: 178 ns per loop

In [5]: r = re2.compile('(?P<test>\w*)')

In [6]: %timeit r.match('foo bar')
1000000 loops, best of 3: 184 ns per loop

In [7]: email_regex = '(?:[a-z0-9!#$%&\'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&\'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])'

In [8]: r = re2.compile(email_regex)

In [9]: %timeit r.match('foo@bar.com')
1000000 loops, best of 3: 774 ns per loop
```
PS: Also here's pprof execution graphs for `timeit()` test before and after the changes:
![upstream-pprof](https://user-images.githubusercontent.com/8562/43414183-f13a3858-9429-11e8-86c8-87c30cf12b5f.png)

![dev-pprof](https://user-images.githubusercontent.com/8562/43414182-f11cb148-9429-11e8-9b2b-a900a6cd2b09.png)
