### PR TITLE
Fix segmentaion fault on py27 when regexp pattern is invalid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /dist
 *.so
 *.py[co]
+*.egg-info
+.tox/

--- a/_re2.cc
+++ b/_re2.cc
@@ -604,14 +604,14 @@ create_match(PyObject* re, PyObject* string,
     StringPiece* groups)
 {
   MatchObject2* match = PyObject_New(MatchObject2, &Match_Type2);
-  match->re = NULL;
-  match->groups = NULL;
-  match->string = NULL;
-
   if (match == NULL) {
     delete[] groups;
     return NULL;
   }
+  match->re = NULL;
+  match->groups = NULL;
+  match->string = NULL;
+
   match->groups = groups;
   Py_INCREF(re);
   match->re = re;

--- a/_re2.cc
+++ b/_re2.cc
@@ -428,6 +428,7 @@ create_regexp(PyObject* self, PyObject* pattern, PyObject* error_class)
   if (regexp == NULL) {
     return NULL;
   }
+  regexp->pattern = NULL;
   regexp->re2_obj = NULL;
   regexp->groupindex = NULL;
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 setup(
     name="fb-re2",
@@ -17,6 +17,7 @@ setup(
     maintainer="Siddharth Agarwal",
     maintainer_email="sid0@fb.com",
     py_modules = ["re2"],
+    test_suite = "tests.test_match.TestMatch",
     ext_modules = [Extension("_re2",
       sources = ["_re2.cc"],
       libraries = ["re2"],

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py27, py36, py37
+
+
+[testenv]
+commands = python setup.py test


### PR DESCRIPTION
Before fix:
```
Verify that bad patterns raise an exception ... 
Program received signal SIGSEGV, Segmentation fault.
0x00007ffff4defd9b in regexp_dealloc (self=0x7ffff55fc360) at _re2.cc:419
419	  Py_XDECREF(self->pattern);
(gdb) bt
#0  0x00007ffff4defd9b in regexp_dealloc (self=0x7ffff55fc360) at _re2.cc:419
#1  0x00007ffff4df02dd in create_regexp (self=<optimized out>, error_class=0x555555b54d60, pattern=0x7ffff7e7e918) at _re2.cc:462
#2  _compile (self=<optimized out>, args=<optimized out>) at _re2.cc:1017
#3  0x000055555564a4ca in call_function (oparg=<optimized out>, pp_stack=0x7fffffffac00) at ../Python/ceval.c:4372
#4  PyEval_EvalFrameEx () at ../Python/ceval.c:3009
#5  0x000055555564f232 in fast_function (nk=<optimized out>, na=<optimized out>, n=1, pp_stack=0x7fffffffad10, func=<optimized out>) at ../Python/ceval.c:4457
#6  call_function (oparg=<optimized out>, pp_stack=0x7fffffffad10) at ../Python/ceval.c:4392
#7  PyEval_EvalFrameEx () at ../Python/ceval.c:3009
#8  0x0000555555647d0a in PyEval_EvalCodeEx () at ../Python/ceval.c:3604
#9  0x00005555556638bc in function_call.lto_priv () at ../Objects/funcobject.c:523
```
After
```
pyre2 git:(fixes) ✗ tox -e py27                                  
GLOB sdist-make: /home/noxiouz/Documents/github/pyre2/setup.py
py27 inst-nodeps: /home/noxiouz/Documents/github/pyre2/.tox/.tmp/package/1/fb-re2-1.0.6.zip
py27 installed: fb-re2==1.0.6
py27 run-test-pre: PYTHONHASHSEED='1876052282'
py27 runtests: commands[0] | python setup.py test
running test
running egg_info
writing fb_re2.egg-info/PKG-INFO
writing top-level names to fb_re2.egg-info/top_level.txt
writing dependency_links to fb_re2.egg-info/dependency_links.txt
reading manifest file 'fb_re2.egg-info/SOURCES.txt'
writing manifest file 'fb_re2.egg-info/SOURCES.txt'
running build_ext
building '_re2' extension
x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fno-strict-aliasing -Wdate-time -D_FORTIFY_SOURCE=2 -g -fdebug-prefix-map=/build/python2.7-3hk45v/python2.7-2.7.15~rc1=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -I/usr/include/python2.7 -c _re2.cc -o build/temp.linux-x86_64-2.7/_re2.o -std=c++11
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
x86_64-linux-gnu-g++ -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -Wdate-time -D_FORTIFY_SOURCE=2 -g -fdebug-prefix-map=/build/python2.7-3hk45v/python2.7-2.7.15~rc1=. -fstack-protector-strong -Wformat -Werror=format-security -Wl,-Bsymbolic-functions -Wl,-z,relro -Wdate-time -D_FORTIFY_SOURCE=2 -g -fdebug-prefix-map=/build/python2.7-3hk45v/python2.7-2.7.15~rc1=. -fstack-protector-strong -Wformat -Werror=format-security build/temp.linux-x86_64-2.7/_re2.o -lre2 -o build/lib.linux-x86_64-2.7/_re2.so
copying build/lib.linux-x86_64-2.7/_re2.so -> 
test_add_after_compile (tests.test_match.TestMatch) ... ok
test_add_with_bad_pattern (tests.test_match.TestMatch) ... ok
test_bad_anchoring (tests.test_match.TestMatch) ... ok
test_compiled_match (tests.test_match.TestMatch) ... ok
test_const_match (tests.test_match.TestMatch) ... ok
test_double_compile (tests.test_match.TestMatch) ... ok
test_group_match (tests.test_match.TestMatch) ... ok
test_invalid_pattern (tests.test_match.TestMatch)
Verify that bad patterns raise an exception ... ok
test_match_bad_utf8_bytes (tests.test_match.TestMatch)
Validate that we just return None on invalid utf-8 ... ok
test_match_bytes (tests.test_match.TestMatch)
test that we can match things in the bytes type ... ok
test_match_raise (tests.test_match.TestMatch)
test that using the API incorrectly fails ... ok
test_match_str (tests.test_match.TestMatch)
test that we can match binary things in the str type ... ok
test_match_without_compile (tests.test_match.TestMatch) ... ok
test_named_group_match (tests.test_match.TestMatch) ... ok
test_set_anchor_both (tests.test_match.TestMatch) ... ok
test_set_anchor_start (tests.test_match.TestMatch) ... ok
test_set_unanchored (tests.test_match.TestMatch) ... ok
test_span_type (tests.test_match.TestMatch)
verify that start/end return the native literal integer type ... ok

----------------------------------------------------------------------
Ran 18 tests in 0.004s

OK
_____________________________________________________________________________________________________ summary _____________________________________________________________________________________________________
  py27: commands succeeded
  congratulations :)
➜  pyre2 git:(fixes) ✗ 

```