### PR TITLE
py3: initialize sre.error correctly

### DIFF
--- a/_re2.cc
+++ b/_re2.cc
@@ -452,9 +452,13 @@ create_regexp(PyObject* self, PyObject* pattern, PyObject* error_class)
   }
 
   if (!regexp->re2_obj->ok()) {
-    long code = (long)regexp->re2_obj->error_code();
     const std::string& msg = regexp->re2_obj->error();
+#if PY_MAJOR_VERSION >= 3
+    PyObject* value = Py_BuildValue("s#", msg.data(), msg.length());
+#else
+    long code = (long)regexp->re2_obj->error_code();
     PyObject* value = Py_BuildValue("ls#", code, msg.data(), msg.length());
+#endif
     if (value == NULL) {
       Py_DECREF(regexp);
       return NULL;

--- a/_re2.cc
+++ b/_re2.cc
@@ -454,7 +454,7 @@ create_regexp(PyObject* self, PyObject* pattern, PyObject* error_class)
   if (!regexp->re2_obj->ok()) {
     const std::string& msg = regexp->re2_obj->error();
 #if PY_MAJOR_VERSION >= 3
-    PyObject* value = Py_BuildValue("s#", msg.data(), msg.length());
+    PyObject* value = PyUnicode_FromStringAndSize(msg.data(), msg.length());
 #else
     long code = (long)regexp->re2_obj->error_code();
     PyObject* value = Py_BuildValue("ls#", code, msg.data(), msg.length());

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     maintainer="Siddharth Agarwal",
     maintainer_email="sid0@fb.com",
     py_modules = ["re2"],
-    test_suite = "tests.test_match.TestMatch",
+    test_suite = "tests",
     ext_modules = [Extension("_re2",
       sources = ["_re2.cc"],
       libraries = ["re2"],

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -5,6 +5,6 @@ class TestCompile(unittest.TestCase):
     def test_raise(self):
         with self.assertRaisesRegexp(
             re2.error,
-            'no argument for repetition operator: *'
+            'no argument for repetition operator: \\*'
         ):
             re2.compile('*')

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -1,0 +1,10 @@
+import unittest
+import re2
+
+class TestCompile(unittest.TestCase):
+    def test_raise(self):
+        with self.assertRaisesRegexp(
+            re2.error,
+            'no argument for repetition operator: *'
+        ):
+            re2.compile('*')


### PR DESCRIPTION
Previously, the error message would appear in `err.pattern` instead of
`str(err)`.