### PR TITLE
Replace deprecated `assertRaisesRegexp()` in tests for py3.12

### DIFF
--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -4,7 +4,7 @@ import re2
 
 class TestCompile(unittest.TestCase):
     def test_raise(self):
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             re2.error,
             'no argument for repetition operator: \\*'
         ):

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -159,20 +159,20 @@ class TestMatch(unittest.TestCase):
         self.assertEqual(s.match('baro'), [1])
 
     def test_bad_anchoring(self):
-        with self.assertRaisesRegexp(ValueError, 'anchoring must be one of.*'):
+        with self.assertRaisesRegex(ValueError, 'anchoring must be one of.*'):
             re2.Set(None)
 
-        with self.assertRaisesRegexp(ValueError, 'anchoring must be one of.*'):
+        with self.assertRaisesRegex(ValueError, 'anchoring must be one of.*'):
             re2.Set(15)
 
-        with self.assertRaisesRegexp(ValueError, 'anchoring must be one of.*'):
+        with self.assertRaisesRegex(ValueError, 'anchoring must be one of.*'):
             re2.Set({})
 
     def test_match_without_compile(self):
         s = re2.Set()
         s.add('foo')
 
-        with self.assertRaisesRegexp(RuntimeError, 'Can\'t match\(\) on an.*'):
+        with self.assertRaisesRegex(RuntimeError, 'Can\'t match\(\) on an.*'):
             s.match('bar')
 
     def test_add_after_compile(self):
@@ -180,7 +180,7 @@ class TestMatch(unittest.TestCase):
         s.add('foo')
         s.compile()
 
-        with self.assertRaisesRegexp(RuntimeError,
+        with self.assertRaisesRegex(RuntimeError,
             'Can\'t add\(\) on an already compiled Set'):
             s.add('bar')
 
@@ -199,7 +199,7 @@ class TestMatch(unittest.TestCase):
     def test_add_with_bad_pattern(self):
         s = re2.Set()
 
-        with self.assertRaisesRegexp(ValueError, 'missing \)'):
+        with self.assertRaisesRegex(ValueError, 'missing \)'):
             s.add('(')
 
         with self.assertRaises(TypeError):


### PR DESCRIPTION
Replace the deprecated `assertRaisesRegexp()` method calls with `assertRaisesRegex()`, to fix compatibility with Python 3.12.